### PR TITLE
Mage 2.1.7 compatibility and logic fix

### DIFF
--- a/Model/AccountManagement.php
+++ b/Model/AccountManagement.php
@@ -274,7 +274,7 @@ class AccountManagement extends CustomerAccountManagement
 
         // Add customer attribute filter
         $customerNumberFilter[] = $this->filterBuilder
-            ->setField('customer_number')
+            ->setField($this->advancedLoginConfigProvider->getLoginAttribute())
             ->setConditionType('eq')
             ->setValue($attributeValue)
             ->create();

--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
   "description": "Allows an customer to login via a customer attribute instead of an email.",
   "require": {
     "php": "~5.5.22|~5.6.0|~7.0.0",
-    "magento/module-customer": "100.0.*",
-    "magento/module-store": "100.0.*",
-    "magento/framework": "100.0.*"
+    "magento/module-customer": "100.0.*|100.1.*",
+    "magento/module-store": "100.0.*|100.1.*",
+    "magento/framework": "100.0.*|100.1.*"
   },
   "type": "magento2-module",
   "license": "OSL-3.0",


### PR DESCRIPTION
Updated composer.json to allow for mage 2.1+.

Updated logic to pull attribute used to login from the admin config. Was hardcoded as "customer_number"